### PR TITLE
updated README.md to link to newest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Projection mapping, also known as video mapping and spatial augmented reality, i
 
 The latest version of MapMap can be find at these links:
 
-- [macOS 0.6.1 DMG](http://download.mapmap.info/osx/MapMap-0.6.1-1.dmg) or [macOS 0.6.1 ZIP](http://download.mapmap.info/osx/MapMap-0.6.1-1.zip) - Note that macOS users need to also install [GStreamer](https://gstreamer.freedesktop.org/data/pkg/osx/1.14.0/gstreamer-1.0-1.14.0-x86_64.pkg) separately.
+- [macOS 0.6.2 DMG](http://download.mapmap.info/osx/MapMap-0.6.2-1.dmg) or [macOS 0.6.2 ZIP](http://download.mapmap.info/osx/MapMap-0.6.2-1_macOS.zip) - Note that macOS users need to also install [GStreamer](https://gstreamer.freedesktop.org/data/pkg/osx/1.14.0/gstreamer-1.0-1.14.0-x86_64.pkg) separately.
 - [Linux APT repository](https://launchpad.net/~mapmap/+archive/ubuntu/mapmap)
-- [Windows 0.5.0 installer](http://download.mapmap.info/windows/mapmap-0.5.0-x86-installer.exe)
-- [Source code 0.6.1 tarball](http://download.mapmap.info/tarballs/mapmap-0.6.1.tar.gz)
+- [Windows 0.6.3 installer](http://download.mapmap.info/windows/mapmap-0.6.3-x86-installer.exe)
+- [Source code 0.6.2 tarball](http://download.mapmap.info/tarballs/mapmap-0.6.2.tar.gz)
 - [Source code Git repository of MapMap](https://github.com/mapmapteam/mapmap)
 
 Older versions:


### PR DESCRIPTION
Previously, README.md has been linking to old versions of the software even though newer binaries and tarballs exists